### PR TITLE
Notebook exploring biased random walks based on user movement between adjacent pages 

### DIFF
--- a/notebooks/random_walk/Biased random walks.ipynb
+++ b/notebooks/random_walk/Biased random walks.ipynb
@@ -1,0 +1,481 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c2c92b6d",
+   "metadata": {},
+   "source": [
+    "# Adding transition probabilities to random walks\n",
+    "\n",
+    "This notebook creates transition probability matrices based on user movement between pages for a *1)* directed graph, and an *2)* undirected graph. Performs repeated random walks using the probability matrices for both the directed and undirected graph, and saves both outputs as a csv file. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "8a9d3bae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import networkx as nx\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from scipy.sparse import csr_matrix\n",
+    "import randomwalks as rw"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc0f83b0",
+   "metadata": {},
+   "source": [
+    "## Create transition matrix"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2ecb420",
+   "metadata": {},
+   "source": [
+    "### Directed graph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "6e2ce374",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<ipython-input-3-0cb2f4f8a887>:12: RuntimeWarning: invalid value encountered in true_divide\n",
+      "  T_probs = T_array / sum_of_rows[:, np.newaxis]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Get directed graph\n",
+    "G = nx.read_gpickle(\"../../data/processed/functional_directed_graph_uk.gpickle\")\n",
+    "\n",
+    "# Create array with edge weight\n",
+    "T = nx.adjacency_matrix(G, weight='edgeWeight').todense()\n",
+    "T_array = np.array(T)\n",
+    "\n",
+    "# Transform edge weight into probabilities\n",
+    "\n",
+    "# Normalisation \n",
+    "sum_of_rows = T_array.sum(axis=1)\n",
+    "T_probs = T_array / sum_of_rows[:, np.newaxis]\n",
+    "\n",
+    "# Rows with only 0s = nan. Replace nan values with 1/Tarray.shape[0]\n",
+    "np.nan_to_num(T_probs, nan=1/T_array.shape[0], copy=False)\n",
+    "\n",
+    "# Convert into a transition matrix (for random walks function)\n",
+    "T_directed = csr_matrix(T_probs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5d8e1c8",
+   "metadata": {},
+   "source": [
+    "### Undirected graph\n",
+    "*G.to_undirected() can not be used to control what data the undirected edges get, therefore we need to create a new graph and sum the edge weights*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "48de1677",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a copy of the edges with weight = 0 \n",
+    "G_undirected = nx.Graph()\n",
+    "G_undirected.add_nodes_from(G.nodes(data=True))\n",
+    "G_undirected.add_edges_from(G.edges, edgeWeight=0)\n",
+    "\n",
+    "# Sum weights for each edge\n",
+    "for u, v, d in G.edges(data=True):\n",
+    "    G_undirected[u][v]['edgeWeight'] += d['edgeWeight']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c0961e68",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create array with edge weight\n",
+    "T_undirected = nx.adjacency_matrix(G_undirected, weight='edgeWeight').todense()\n",
+    "T_undirected_array = np.array(T_undirected)\n",
+    "\n",
+    "# Normalisation \n",
+    "sum_of_rows = T_undirected_array.sum(axis=1)\n",
+    "T_undirected_probs = T_undirected_array / sum_of_rows[:, np.newaxis]\n",
+    "np.nan_to_num(T_undirected_probs, nan=1/T_undirected_array.shape[0], copy=False)\n",
+    "\n",
+    "# Convert into a transition matrix (for random walks function)\n",
+    "T_undirected = csr_matrix(T_undirected_probs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c00b108d",
+   "metadata": {},
+   "source": [
+    "## Random walks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "180caef1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set the seeds from where random walks will be initialised\n",
+    "seeds = ('/browse/visas-immigration/work-visas',\n",
+    "'/browse/visas-immigration/what-you-need-to-do',\n",
+    "'/check-uk-visa',\n",
+    "'/apply-to-come-to-the-uk',\n",
+    "'/contact-ukvi-inside-outside-uk',\n",
+    "'/skilled-worker-visa'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42c4d79c",
+   "metadata": {},
+   "source": [
+    "### Directed graph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "1965a367",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Reformat the graph to make it compliant with existing random walk functions\n",
+    "# i.e. add the path to a name property and set the index to be a number\n",
+    "for index,data in G.nodes(data=True):\n",
+    "    data['properties'] = dict()\n",
+    "    data['properties']['name'] = index\n",
+    "\n",
+    "G = nx.convert_node_labels_to_integers(G, first_label=0, ordering='default', label_attribute=None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "4132a51d",
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b94607a311084b9abd3b5467b979e11f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/6 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "results_directed = rw.repeat_random_walks(steps=100, repeats=100, T=T_directed, G=G, seed_pages=seeds, proba=True, combine='union', level=1, n_jobs=1)\n",
+    "page_scores_directed = rw.page_freq_path_freq_ranking(results_directed)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a0116d2b",
+   "metadata": {},
+   "source": [
+    "### Undirected graph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "e131881a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# reformat the graph to make it compliant with existing random walk functions\n",
+    "# i.e. add the path to a name property and set the index to be a number\n",
+    "for index,data in G_undirected.nodes(data=True):\n",
+    "    data['properties'] = dict()\n",
+    "    data['properties']['name'] = index\n",
+    "\n",
+    "G_undirected = nx.convert_node_labels_to_integers(G_undirected, first_label=0, ordering='default', label_attribute=None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "fb733ac1",
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8819a81252ef4a7c8f6ad914ceb80f1c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/6 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "results_undirected = rw.repeat_random_walks(steps=100, repeats=100, T=T_undirected, G=G_undirected, seed_pages=seeds, proba=True, combine='union', level=1, n_jobs=1)\n",
+    "page_scores_undirected = rw.page_freq_path_freq_ranking(results_undirected)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70724ce2",
+   "metadata": {},
+   "source": [
+    "## Create output\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "0e2f90bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Document supertypes\n",
+    "news_and_comms_doctypes = {'medical_safety_alert', 'drug_safety_update', 'news_article', \n",
+    "                           'news_story', 'press_release', 'world_location_news_article', \n",
+    "                           'world_news_story', 'fatality_notice', 'fatality_notice', \n",
+    "                           'tax_tribunal_decision', 'utaac_decision', 'asylum_support_decision', \n",
+    "                           'employment_appeal_tribunal_decision', 'employment_tribunal_decision', \n",
+    "                           'employment_tribunal_decision', 'service_standard_report', 'cma_case', \n",
+    "                           'decision', 'oral_statement', 'written_statement', 'authored_article', \n",
+    "                           'correspondence', 'speech', 'government_response', 'case_study' \n",
+    "}\n",
+    "\n",
+    "service_doctypes = {'completed_transaction', 'local_transaction', 'form', 'calculator',\n",
+    "                    'smart_answer', 'simple_smart_answer', 'place', 'licence', 'step_by_step_nav', \n",
+    "                    'transaction', 'answer', 'guide'\n",
+    "}\n",
+    "\n",
+    "guidance_and_reg_doctypes = {'regulation', 'detailed_guide', 'manual', 'manual_section',\n",
+    "                             'guidance', 'map', 'calendar', 'statutory_guidance', 'notice',\n",
+    "                             'international_treaty', 'travel_advice', 'promotional', \n",
+    "                             'international_development_fund', 'countryside_stewardship_grant',\n",
+    "                             'esi_fund', 'business_finance_support_scheme', 'statutory_instrument',\n",
+    "                             'hmrc_manual', 'standard'\n",
+    "}\n",
+    "\n",
+    "policy_and_engage_doctypes = {'impact_assessment', 'policy_paper', 'open_consultation',\n",
+    "                              'policy_paper', 'closed_consultation', 'consultation_outcome',\n",
+    "                              'policy_and_engagement'  \n",
+    "}\n",
+    "\n",
+    "research_and_stats_doctypes = {'dfid_research_output', 'independent_report', 'research', \n",
+    "                               'statistics', 'national_statistics', 'statistics_announcement',\n",
+    "                               'national_statistics_announcement', 'official_statistics_announcement',\n",
+    "                               'statistical_data_set', 'official_statistics'\n",
+    "}\n",
+    "\n",
+    "transparency_doctypes = {'transparency', 'corporate_report', 'foi_release', 'aaib_report',\n",
+    "                         'raib_report', 'maib_report'\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "795331cc",
+   "metadata": {},
+   "source": [
+    "### Directed graph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "a391fe26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a df with `pagePath`: `documentType`, `sessionHitsAll`, `entranceHit`, `exitHit`, `entranceAndExitHit`\n",
+    "df_dict = {info['properties']['name']: [info['documentType'], info['sessionHitsAll'], info['entranceHit'], info['exitHit'], info['entranceAndExitHit']] for node, info in G.nodes(data=True)}\n",
+    "df_dict = {k:v for (k,v) in df_dict.items() if k in page_scores_directed['pagePath'].tolist()}\n",
+    "df_info = pd.DataFrame.from_dict(df_dict, orient='index', columns=['documentType', 'sessionHitsAll', 'entranceHit', 'exitHit', 'entranceAndExitHit']).rename_axis('pagePath').reset_index()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "e018e721",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a df with document supertypes\n",
+    "document_type_dict = dict.fromkeys(list(set(df_info['documentType'])))\n",
+    "\n",
+    "for docType, docSupertype in document_type_dict.items():\n",
+    "    if docType in news_and_comms_doctypes: \n",
+    "        document_type_dict[docType] = 'news and communication'\n",
+    "    \n",
+    "    elif docType in service_doctypes:\n",
+    "        document_type_dict[docType] = 'services'\n",
+    "    \n",
+    "    elif docType in guidance_and_reg_doctypes:\n",
+    "        document_type_dict[docType] = 'guidance and regulation'\n",
+    " \n",
+    "    elif docType in policy_and_engage_doctypes:\n",
+    "        document_type_dict[docType] = 'policy and engagement'\n",
+    "    \n",
+    "    elif docType in research_and_stats_doctypes:\n",
+    "        document_type_dict[docType] = 'research and statistics'\n",
+    "    \n",
+    "    elif docType in transparency_doctypes:\n",
+    "        document_type_dict[docType] = 'transparency'\n",
+    "    \n",
+    "    else: \n",
+    "        document_type_dict[docType] = 'other' \n",
+    "\n",
+    "df_docSuper = pd.DataFrame(document_type_dict.items(), columns=['documentType', 'documentSupertype'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "42efecc5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Merge dfs \n",
+    "df_merged = pd.merge(page_scores_directed, df_info, on='pagePath')\n",
+    "df_merged = pd.merge(df_merged, df_docSuper, how='left')\n",
+    "\n",
+    "# Reoder and rename df columns \n",
+    "df_merged = df_merged[['pagePath', 'documentType', 'documentSupertype', 'sessionHitsAll', 'entranceHit', 'exitHit', 'entranceAndExitHit', 'tfdf_max']]\n",
+    "df_merged = df_merged.rename(columns={'pagePath': 'page path', 'documentType': 'document type', 'documentSupertype': 'document supertype', 'sessionHitsAll': 'number of sessions that visit this page', 'entranceHit': 'number of sessions where this page is an entrance hit', 'exitHit': 'number of sessions where this page is an exit hit', 'entranceAndExitHit': 'number of sessions where this page is both an entrance and exit hit', 'tfdf_max': 'how frequent the page occurs in the whole user journey'})\n",
+    "\n",
+    "# Save df\n",
+    "df_merged.to_csv('../../outputs/pages_ranked_directed_uk.csv', index=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ba59f8d",
+   "metadata": {},
+   "source": [
+    "### Undirected graph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "c8b2563a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a df with `pagePath`: `documentType`, `sessionHitsAll`, `entranceHit`, `exitHit`, `entranceAndExitHit`\n",
+    "df_dict = {info['properties']['name']: [info['documentType'], info['sessionHitsAll'], info['entranceHit'], info['exitHit'], info['entranceAndExitHit']] for node, info in G_undirected.nodes(data=True)}\n",
+    "df_dict = {k:v for (k,v) in df_dict.items() if k in page_scores_undirected['pagePath'].tolist()}\n",
+    "df_info = pd.DataFrame.from_dict(df_dict, orient='index', columns=['documentType', 'sessionHitsAll', 'entranceHit', 'exitHit', 'entranceAndExitHit']).rename_axis('pagePath').reset_index()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "68e627e6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a df with document supertypes\n",
+    "document_type_dict = dict.fromkeys(list(set(df_info['documentType'])))\n",
+    "\n",
+    "for docType, docSupertype in document_type_dict.items():\n",
+    "    if docType in news_and_comms_doctypes: \n",
+    "        document_type_dict[docType] = 'news and communication'\n",
+    "    \n",
+    "    elif docType in service_doctypes:\n",
+    "        document_type_dict[docType] = 'services'\n",
+    "    \n",
+    "    elif docType in guidance_and_reg_doctypes:\n",
+    "        document_type_dict[docType] = 'guidance and regulation'\n",
+    " \n",
+    "    elif docType in policy_and_engage_doctypes:\n",
+    "        document_type_dict[docType] = 'policy and engagement'\n",
+    "    \n",
+    "    elif docType in research_and_stats_doctypes:\n",
+    "        document_type_dict[docType] = 'research and statistics'\n",
+    "    \n",
+    "    elif docType in transparency_doctypes:\n",
+    "        document_type_dict[docType] = 'transparency'\n",
+    "    \n",
+    "    else: \n",
+    "        document_type_dict[docType] = 'other' \n",
+    "\n",
+    "df_docSuper = pd.DataFrame(document_type_dict.items(), columns=['documentType', 'documentSupertype'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "16975a03",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Merge dfs \n",
+    "df_merged = pd.merge(page_scores_undirected, df_info, on='pagePath')\n",
+    "df_merged = pd.merge(df_merged, df_docSuper, how='left')\n",
+    "\n",
+    "# Reoder and rename df columns \n",
+    "df_merged = df_merged[['pagePath', 'documentType', 'documentSupertype', 'sessionHitsAll', 'entranceHit', 'exitHit', 'entranceAndExitHit', 'tfdf_max']]\n",
+    "df_merged = df_merged.rename(columns={'pagePath': 'page path', 'documentType': 'document type', 'documentSupertype': 'document supertype', 'sessionHitsAll': 'number of sessions that visit this page', 'entranceHit': 'number of sessions where this page is an entrance hit', 'exitHit': 'number of sessions where this page is an exit hit', 'entranceAndExitHit': 'number of sessions where this page is both an entrance and exit hit', 'tfdf_max': 'how frequent the page occurs in the whole user journey'})\n",
+    "\n",
+    "# Save df\n",
+    "df_merged.to_csv('../../outputs/pages_ranked_undirected_uk.csv', index=False)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
# Summary

This notebook explores biased random walks based on user movement between adjacent pages (i.e greater probability transitioning to an adjacent page = greater user movement between pages). Explored for both a directed and undirected graph. This notebook focuses on the 'moving to the UK for work' whole user journey. 

1) Loads in the directed graph 
2) Creates a transition probability matrix for the directed graph
3) Creates undirected graph
4) Creates a transition probability matrix for the undirected graph
5) Runs random walks and ranking method on directed graph
6) Runs random walks and ranking method on undirected graph
7) Creates and saves output csv for the directed graph
8) Creates and saves output csv for the undirected graph

# Checklists

<!--
These are do-confirm checklists; it confirms that you have DOne each item.

Outstanding actions should be completed before reviewers are assigned; if actions are
irrelevant, please try and add a comment stating why.

Incomplete pull/merge requests may be blocked until actions are resolved, or closed at
the reviewers' discretion.
-->

This pull/merge request meets the following requirements:

- [X] code runs
- [X] [developments are ethical][data-ethics-framework] and secure
- [X] you have made proportionate checks that the code works correctly
- [ ] test suite passes
- [ ] developments adhere to AQA plan (see `docs/aqa/aqa_plan.md`)
- [ ] data log updated (see `docs/aqa/data_log.md`), if necessary
- [ ] assumptions, and caveats log updated (see `docs/aqa/assumptions_caveats.md`), if
  necessary
- [ ] [minimum usable documentation][agilemodeling] written in the `docs` folder

[agilemodeling]: http://agilemodeling.com/essays/documentLate.htm
[data-ethics-framework]: https://www.gov.uk/government/publications/data-ethics-framework
