### PR TITLE
Adding total session hits to page view random walks approach

### DIFF
--- a/notebooks/page view functional network/step_four_create_networkx_graph.ipynb
+++ b/notebooks/page view functional network/step_four_create_networkx_graph.ipynb
@@ -107,6 +107,7 @@
     "nx.set_node_attributes(G, pd.Series(nodes.sourcePageSessionHitsEntranceOnly.values, index=nodes.sourcePagePath).to_dict(), 'entranceHit')\n",
     "nx.set_node_attributes(G, pd.Series(nodes.sourcePageSessionHitsExitOnly.values, index=nodes.sourcePagePath).to_dict(), 'exitHit')\n",
     "nx.set_node_attributes(G, pd.Series(nodes.sourcePageSessionHitsEntranceAndExit.values, index=nodes.sourcePagePath).to_dict(), 'entranceAndExitHit')\n",
+    "nx.set_node_attributes(G, pd.Series(nodes.sessionHits.values, index=nodes.sourcePagePath).to_dict(), 'sessionHits')\n",
     "\n",
     "# save functional graph \n",
     "nx.write_gpickle(G, \"../data/processed/functional_session_hit_directed_graph_er.gpickle\")"
@@ -118,7 +119,7 @@
    "hash": "c6313e0c8b41eb13583c36725f8a1f1fa69ba497bb7e6eaf409642bf47446516"
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/notebooks/page view functional network/step_three_extract_nodes_and_edges.sql
+++ b/notebooks/page view functional network/step_three_extract_nodes_and_edges.sql
@@ -101,7 +101,7 @@ session_hits AS (
         bottomLevelTaxons,
         isEntrance,
         isExit,
-        sessionHits
+        sessionHits,
         CASE WHEN (isEntrance AND isExit) THEN 'isEntranceAndExit'
              WHEN (isExit AND isEntrance IS NULL) THEN 'isEntrance'
              WHEN (isEntrance AND isExit IS NULL) THEN 'isExit'

--- a/notebooks/page view functional network/step_three_extract_nodes_and_edges.sql
+++ b/notebooks/page view functional network/step_three_extract_nodes_and_edges.sql
@@ -52,6 +52,7 @@ OUTPUT:
     - Node property = `sourcePageSessionEntranceOnly`
     - Node property = `sourcePageSessionExitOnly`
     - Node property = `sourcePageSessionEntranceAndExit`
+    - Node property = `sessionHits`
   - `govuk-bigquery-analytics.wuj_network_analysis.edges_er`
     - Edges = `sourcePagePath` to `destinationPagePath`
     - Edge weight = `edgeWeight`
@@ -85,6 +86,7 @@ source_destination_page_path AS (
         bottomLevelTaxons,
         isEntrance,
         isExit,
+        sessionHits,
         LEAD(pagePath) OVER (PARTITION BY sessionId ORDER BY hitNumber) AS destinationPagePath
     FROM page_view_approach
 ),
@@ -99,12 +101,13 @@ session_hits AS (
         bottomLevelTaxons,
         isEntrance,
         isExit,
+        sessionHits
         CASE WHEN (isEntrance AND isExit) THEN 'isEntranceAndExit'
              WHEN (isExit AND isEntrance IS NULL) THEN 'isEntrance'
              WHEN (isEntrance AND isExit IS NULL) THEN 'isExit'
         END AS entranceOrExit
 FROM source_destination_page_path
-GROUP BY sessionId, sourcePagePath, documentType, topLevelTaxons, bottomLevelTaxons, isEntrance, isExit
+GROUP BY sessionId, sourcePagePath, documentType, topLevelTaxons, bottomLevelTaxons, isEntrance, isExit, sessionHits
 ),
 
 -- aggregate rows over session, pagePath, document type, top level taxons, and 
@@ -117,9 +120,10 @@ session_hits_all AS (
         documentType,
         topLevelTaxons,
         bottomLevelTaxons,
+        sessionHits,
         STRING_AGG(CAST(entranceOrExit AS STRING)) AS allTypesOfHitsInSession
     FROM session_hits
-    GROUP BY sessionId, sourcePagePath, documentType, topLevelTaxons, bottomLevelTaxons
+    GROUP BY sessionId, sourcePagePath, documentType, topLevelTaxons, bottomLevelTaxons, sessionHits
     ORDER BY allTypesOfHitsInSession
 ),
 
@@ -133,12 +137,13 @@ pages_with_all_counts AS (
         documentType,
         topLevelTaxons,
         bottomLevelTaxons,
+        sessionHits,
         COUNT(DISTINCT sessionId) AS sourcePageSessionHitsAll,
         COUNT(DISTINCT (CASE WHEN allTypesOfHitsInSession = 'isEntrance' THEN sessionId ELSE null END) ) AS sourcePageSessionHitsEntranceOnly,
         COUNT(DISTINCT (CASE WHEN allTypesOfHitsInSession = 'isExit' THEN sessionId ELSE null END) ) AS sourcePageSessionHitsExitOnly,
         COUNT(DISTINCT (CASE WHEN STARTS_WITH(allTypesOfHitsInSession, 'isEntranceAndExit') OR STARTS_WITH(allTypesOfHitsInSession, 'isEntrance,') OR STARTS_WITH(allTypesOfHitsInSession, 'isExit,') THEN sessionId ELSE null END) ) AS sourcePageSessionHitsEntranceAndExit
     FROM session_hits_all 
-    GROUP BY sourcePagePath, documentType, topLevelTaxons, bottomLevelTaxons
+    GROUP BY sourcePagePath, documentType, topLevelTaxons, bottomLevelTaxons, sessionHits
     ORDER BY sourcePageSessionHitsAll DESC
 ),
 

--- a/notebooks/random_walk/Biased random walks.ipynb
+++ b/notebooks/random_walk/Biased random walks.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "c2c92b6d",
+   "id": "130463fc",
    "metadata": {},
    "source": [
     "# Adding transition probabilities to random walks\n",
@@ -13,7 +13,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "8a9d3bae",
+   "id": "dcc0e827",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cc0f83b0",
+   "id": "2ef75e5e",
    "metadata": {},
    "source": [
     "## Create transition matrix"
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b2ecb420",
+   "id": "d4bb7708",
    "metadata": {},
    "source": [
     "### Directed graph"
@@ -43,7 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "6e2ce374",
+   "id": "de9c9b25",
    "metadata": {},
    "outputs": [
     {
@@ -78,7 +78,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d5d8e1c8",
+   "id": "1ec45b54",
    "metadata": {},
    "source": [
     "### Undirected graph\n",
@@ -88,7 +88,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "48de1677",
+   "id": "6b31ed38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -105,7 +105,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "c0961e68",
+   "id": "9a9645e8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -124,7 +124,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c00b108d",
+   "id": "5c2e851c",
    "metadata": {},
    "source": [
     "## Random walks"
@@ -133,7 +133,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "180caef1",
+   "id": "6a5cde1d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -149,7 +149,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42c4d79c",
+   "id": "debef2c8",
    "metadata": {},
    "source": [
     "### Directed graph"
@@ -158,7 +158,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "1965a367",
+   "id": "542ae0ce",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,7 +174,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "4132a51d",
+   "id": "e82a0f99",
    "metadata": {
     "collapsed": true
    },
@@ -201,7 +201,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a0116d2b",
+   "id": "a837e625",
    "metadata": {},
    "source": [
     "### Undirected graph"
@@ -210,7 +210,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "e131881a",
+   "id": "8889a366",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -226,7 +226,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "fb733ac1",
+   "id": "a64bcecc",
    "metadata": {
     "collapsed": true
    },
@@ -253,7 +253,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "70724ce2",
+   "id": "684070d0",
    "metadata": {},
    "source": [
     "## Create output\n"
@@ -262,7 +262,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "0e2f90bc",
+   "id": "4459303c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -308,7 +308,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "795331cc",
+   "id": "5017f131",
    "metadata": {},
    "source": [
     "### Directed graph"
@@ -317,20 +317,20 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "a391fe26",
+   "id": "aa273c30",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Create a df with `pagePath`: `documentType`, `sessionHitsAll`, `entranceHit`, `exitHit`, `entranceAndExitHit`\n",
-    "df_dict = {info['properties']['name']: [info['documentType'], info['sessionHitsAll'], info['entranceHit'], info['exitHit'], info['entranceAndExitHit']] for node, info in G.nodes(data=True)}\n",
+    "df_dict = {info['properties']['name']: [info['documentType'], info['sessionHitsAll'], info['entranceHit'], info['exitHit'], info['entranceAndExitHit'], info['sessionHits']] for node, info in G.nodes(data=True)}\n",
     "df_dict = {k:v for (k,v) in df_dict.items() if k in page_scores_directed['pagePath'].tolist()}\n",
-    "df_info = pd.DataFrame.from_dict(df_dict, orient='index', columns=['documentType', 'sessionHitsAll', 'entranceHit', 'exitHit', 'entranceAndExitHit']).rename_axis('pagePath').reset_index()"
+    "df_info = pd.DataFrame.from_dict(df_dict, orient='index', columns=['documentType', 'sessionHitsAll', 'entranceHit', 'exitHit', 'entranceAndExitHit', 'sessionHits']).rename_axis('pagePath').reset_index()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "e018e721",
+   "id": "c2c530ed",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -365,7 +365,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "42efecc5",
+   "id": "36b916d6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -374,8 +374,8 @@
     "df_merged = pd.merge(df_merged, df_docSuper, how='left')\n",
     "\n",
     "# Reoder and rename df columns \n",
-    "df_merged = df_merged[['pagePath', 'documentType', 'documentSupertype', 'sessionHitsAll', 'entranceHit', 'exitHit', 'entranceAndExitHit', 'tfdf_max']]\n",
-    "df_merged = df_merged.rename(columns={'pagePath': 'page path', 'documentType': 'document type', 'documentSupertype': 'document supertype', 'sessionHitsAll': 'number of sessions that visit this page', 'entranceHit': 'number of sessions where this page is an entrance hit', 'exitHit': 'number of sessions where this page is an exit hit', 'entranceAndExitHit': 'number of sessions where this page is both an entrance and exit hit', 'tfdf_max': 'how frequent the page occurs in the whole user journey'})\n",
+    "df_merged = df_merged[['pagePath', 'documentType', 'documentSupertype', 'sessionHitsAll', 'entranceHit', 'exitHit', 'entranceAndExitHit', 'sessionHits', 'tfdf_max']]\n",
+    "df_merged = df_merged.rename(columns={'pagePath': 'page path', 'documentType': 'document type', 'documentSupertype': 'document supertype', 'sessionHitsAll': 'number of sessions that visit this page', 'entranceHit': 'number of sessions where this page is an entrance hit', 'exitHit': 'number of sessions where this page is an exit hit', 'entranceAndExitHit': 'number of sessions where this page is both an entrance and exit hit', 'sessionHits': 'all sessions that visit this page, regardless of the session visiting a seed page', 'tfdf_max': 'how frequent the page occurs in the whole user journey'})\n",
     "\n",
     "# Save df\n",
     "df_merged.to_csv('../../outputs/pages_ranked_directed_uk.csv', index=False)"
@@ -383,7 +383,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8ba59f8d",
+   "id": "d3127502",
    "metadata": {},
    "source": [
     "### Undirected graph"
@@ -392,20 +392,20 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "c8b2563a",
+   "id": "d77cb5f3",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Create a df with `pagePath`: `documentType`, `sessionHitsAll`, `entranceHit`, `exitHit`, `entranceAndExitHit`\n",
-    "df_dict = {info['properties']['name']: [info['documentType'], info['sessionHitsAll'], info['entranceHit'], info['exitHit'], info['entranceAndExitHit']] for node, info in G_undirected.nodes(data=True)}\n",
+    "df_dict = {info['properties']['name']: [info['documentType'], info['sessionHitsAll'], info['entranceHit'], info['exitHit'], info['entranceAndExitHit'], info['sessionHits']] for node, info in G_undirected.nodes(data=True)}\n",
     "df_dict = {k:v for (k,v) in df_dict.items() if k in page_scores_undirected['pagePath'].tolist()}\n",
-    "df_info = pd.DataFrame.from_dict(df_dict, orient='index', columns=['documentType', 'sessionHitsAll', 'entranceHit', 'exitHit', 'entranceAndExitHit']).rename_axis('pagePath').reset_index()"
+    "df_info = pd.DataFrame.from_dict(df_dict, orient='index', columns=['documentType', 'sessionHitsAll', 'entranceHit', 'exitHit', 'entranceAndExitHit', 'sessionHits']).rename_axis('pagePath').reset_index()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "68e627e6",
+   "id": "b2a48323",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -440,7 +440,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "16975a03",
+   "id": "0af022a0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -449,8 +449,8 @@
     "df_merged = pd.merge(df_merged, df_docSuper, how='left')\n",
     "\n",
     "# Reoder and rename df columns \n",
-    "df_merged = df_merged[['pagePath', 'documentType', 'documentSupertype', 'sessionHitsAll', 'entranceHit', 'exitHit', 'entranceAndExitHit', 'tfdf_max']]\n",
-    "df_merged = df_merged.rename(columns={'pagePath': 'page path', 'documentType': 'document type', 'documentSupertype': 'document supertype', 'sessionHitsAll': 'number of sessions that visit this page', 'entranceHit': 'number of sessions where this page is an entrance hit', 'exitHit': 'number of sessions where this page is an exit hit', 'entranceAndExitHit': 'number of sessions where this page is both an entrance and exit hit', 'tfdf_max': 'how frequent the page occurs in the whole user journey'})\n",
+    "df_merged = df_merged[['pagePath', 'documentType', 'documentSupertype', 'sessionHitsAll', 'entranceHit', 'exitHit', 'entranceAndExitHit', 'sessionHits', 'tfdf_max']]\n",
+    "df_merged = df_merged.rename(columns={'pagePath': 'page path', 'documentType': 'document type', 'documentSupertype': 'document supertype', 'sessionHitsAll': 'number of sessions that visit this page', 'entranceHit': 'number of sessions where this page is an entrance hit', 'exitHit': 'number of sessions where this page is an exit hit', 'entranceAndExitHit': 'number of sessions where this page is both an entrance and exit hit', 'sessionHits': 'all sessions that visit this page, regardless of the session visiting a seed page', 'tfdf_max': 'how frequent the page occurs in the whole user journey'})\n",
     "\n",
     "# Save df\n",
     "df_merged.to_csv('../../outputs/pages_ranked_undirected_uk.csv', index=False)"


### PR DESCRIPTION
# Summary

Added a total session hits count to the wuj output, using the page view random walks approach. This is a total session hit count that is regardless of whether the session also visited a seed page. 

# Checklists

<!--
These are do-confirm checklists; it confirms that you have DOne each item.

Outstanding actions should be completed before reviewers are assigned; if actions are
irrelevant, please try and add a comment stating why.

Incomplete pull/merge requests may be blocked until actions are resolved, or closed at
the reviewers' discretion.
-->

This pull/merge request meets the following requirements:

- [X] code runs
- [X] [developments are ethical][data-ethics-framework] and secure
- [X] you have made proportionate checks that the code works correctly
- [ ] test suite passes
- [ ] developments adhere to AQA plan (see `docs/aqa/aqa_plan.md`)
- [ ] data log updated (see `docs/aqa/data_log.md`), if necessary
- [ ] assumptions, and caveats log updated (see `docs/aqa/assumptions_caveats.md`), if
  necessary
- [ ] [minimum usable documentation][agilemodeling] written in the `docs` folder

Comments have been added below around the incomplete checks.

[agilemodeling]: http://agilemodeling.com/essays/documentLate.htm
[data-ethics-framework]: https://www.gov.uk/government/publications/data-ethics-framework
